### PR TITLE
address CRAN review

### DIFF
--- a/src/RaveIO.cpp
+++ b/src/RaveIO.cpp
@@ -769,7 +769,6 @@ public:
     PolarVolume_t *volume = NULL;
     PolarVolume result;
     char *fileIn[INPUTFILESMAX];
-    int initSuccessful = 0;
 
     if (files.size() == 0) {
       throw std::invalid_argument("Must specify at least one input filename");

--- a/src/librsl/rainbow_to_radar.c
+++ b/src/librsl/rainbow_to_radar.c
@@ -173,7 +173,8 @@ int rainbow_data_to_radar(Radar *radar, Rainbow_hdr rainbow_hdr, FILE *fp)
      * and sweeps continues for the remainder of sweeps in the volume scan.
      */
 
-    int iray, isweep, nread, nsweeps, nrays, nbins, vol_index;
+    int iray, isweep, nread, nsweeps, nrays, nbins;
+    int vol_index = -1;
     unsigned char *rainbow_ray;
     Volume *v;
     Sweep *sweep;

--- a/src/librsl/wsr88d_m31.c
+++ b/src/librsl/wsr88d_m31.c
@@ -389,8 +389,8 @@ void wsr88d_load_ray_into_radar(Wsr88d_ray_m31 *wsr88d_ray, int isweep,
     unsigned short item;
     float value, scale, offset;
     unsigned char *data;
-    Range (*invf)(float x);
-    float (*f)(Range x);
+    Range (*invf)(float x) = DZ_INVF;
+    float (*f)(Range x) = DZ_F;
     Ray *ray;
     int vol_index, waveform;
 

--- a/src/librsl/wsr88d_remove_sails_sweep.c
+++ b/src/librsl/wsr88d_remove_sails_sweep.c
@@ -6,7 +6,8 @@ void wsr88d_remove_sails_sweep(Radar *radar)
 
     int i, j;
     int sails_loc[4];
-    int isails, nsails;
+    int isails = 0;
+    int nsails = 0;
 
     if (radar->h.vcp != 12 && radar->h.vcp != 212) return;
 

--- a/src/mistnet.cpp
+++ b/src/mistnet.cpp
@@ -151,6 +151,7 @@ void rave_alloc_print_statistics(void);
 
 //' The software has to be compiled with -DRAVE_MEMORY_DEBUG and without -DNO_RAVE_PRINTF.
 //' Manual handling for now.
+//' @keywords internal
 // [[Rcpp::export]]
 void cpp_printMemory() {
   RaveCoreObject_printStatistics();


### PR DESCRIPTION
Thanks, we see:


valgrind: (was uninitialized values)  Better, but in the light of the past errors

librsl/rainbow_to_radar.c:211:8: warning: ‘vol_index’ may be used uninitialized [-Wmaybe-uninitialized]

librsl/wsr88d_m31.c:458:38: warning: ‘f’ may be used uninitialized in this function [-Wmaybe-uninitialized]

librsl/wsr88d_m31.c:459:41: warning: ‘invf’ may be used uninitialized in this function [-Wmaybe-uninitialized]

librsl/wsr88d_remove_sails_sweep.c:37:9: warning: ‘nsails’ may be used uninitialized in this function [-Wmaybe-uninitialized]

should be corrected.


Please fix and resubmit.
