### PR TITLE
Missing dependency on rocker/tidyverse

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -85,9 +85,9 @@ Homebrew.
 
 | System                                      | Command                                                                      |
 |:----------------------------------|:------------------------------------|
-| **OS X (using Homebrew)**                   | `brew install hdf5 proj gsl pkg-config`                                      |
-| **Debian-based systems (including Ubuntu)** | `sudo apt-get install libhdf5-dev libproj-dev gsl-bin libgsl-dev pkg-config` |
-| **Systems supporting yum and RPMs**         | `sudo yum install hdf5-devel proj-devel gsl gsl-devel pkgconfig`             |
+| **OS X (using Homebrew)**                   | `brew install hdf5 proj gsl pkg-config`                                                 |
+| **Debian-based systems (including Ubuntu)** | `sudo apt-get install libhdf5-dev libproj-dev gsl-bin libgsl-dev pkg-config libbz2-dev` |
+| **Systems supporting yum and RPMs**         | `sudo yum install hdf5-devel proj-devel gsl gsl-devel pkgconfig`                        |
 
 Next, you can install the released version of 'vol2birdR' from
 [CRAN](https://CRAN.R-project.org) with:

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ Homebrew.
 
 </details>
 
-| System                                      | Command                                                                      |
-|:--------------------------------------------|:-----------------------------------------------------------------------------|
-| **OS X (using Homebrew)**                   | `brew install hdf5 proj gsl pkg-config`                                      |
-| **Debian-based systems (including Ubuntu)** | `sudo apt-get install libhdf5-dev libproj-dev gsl-bin libgsl-dev pkg-config` |
-| **Systems supporting yum and RPMs**         | `sudo yum install hdf5-devel proj-devel gsl gsl-devel pkgconfig`             |
+| System                                      | Command                                                                                 |
+|:--------------------------------------------|:----------------------------------------------------------------------------------------|
+| **OS X (using Homebrew)**                   | `brew install hdf5 proj gsl pkg-config`                                                 |
+| **Debian-based systems (including Ubuntu)** | `sudo apt-get install libhdf5-dev libproj-dev gsl-bin libgsl-dev pkg-config libbz2-dev` |
+| **Systems supporting yum and RPMs**         | `sudo yum install hdf5-devel proj-devel gsl gsl-devel pkgconfig`                        |
 
 Next, you can install the released version of ‘vol2birdR’ from
 [CRAN](https://CRAN.R-project.org) with:


### PR DESCRIPTION
I noticed I needed an other dependency on the `rocker/tidyverse` image, I guess most of the time it is already installed but not there. The compilation failed here without the dependency:
```
gcc -I"/usr/local/lib/R/include" -DNDEBUG -I/usr/include/hdf5/serial -I/usr/include  -I. -I./includes -I./includes/libvol2bird -I./includes/libmistnet -I./includes/librave -I./includes/libhlhdf -I./includes/librsl  -I./includes/libiris2odim -DNOCONFUSE -DMISTNET -DVOL2BIRD_R -DNO_VOL2BIRD_PRINTF  -DNO_HLHDF_PRINTF -DNO_HLHDF_ABORT  -DNO_RAVE_PRINTF -DNO_RAVE_ABORT  -DNO_UNZIP_PIPE -DRSL_NO_STDERR_PRINTF -DRSL=1   -DIRIS_NO_EXIT_OR_STDERR -DIRIS=1 -DENABLE_IRIS2ODIM -I/usr/include -I'/usr/local/lib/R/site-library/Rcpp/include' -I'/usr/local/lib/R/site-library/RcppGSL/include' -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c librsl/wsr88d.c -o librsl/wsr88d.o
librsl/wsr88d.c:71:10: fatal error: bzlib.h: No such file or directory
   71 | #include <bzlib.h>
      |          ^~~~~~~~~
```