### PR TITLE
Patch/sharpyuv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: vol2birdR
 Type: Package
 Title: Vertical Profiles of Biological Signals in Weather Radar Data
-Version: 1.0.1
+Version: 1.0.2
 Date: 2023-05-17
 Authors@R: c(
     person("Anders", "Henja", email = "anders.henja@gmail.com", role = "aut",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: vol2birdR
 Type: Package
 Title: Vertical Profiles of Biological Signals in Weather Radar Data
 Version: 1.0.2
-Date: 2023-05-17
+Date: 2024-01-04
 Authors@R: c(
     person("Anders", "Henja", email = "anders.henja@gmail.com", role = "aut",
     comment = "vol2birdR package author and author of RAVE and HLHDF libraries"),

--- a/codemeta.json
+++ b/codemeta.json
@@ -247,7 +247,7 @@
     },
     "SystemRequirements": "GNU make, GSL, HDF5, PROJ"
   },
-  "fileSize": "14442.861KB",
+  "fileSize": "14588.794KB",
   "releaseNotes": "https://github.com/adokter/vol2birdR/blob/master/NEWS.md",
   "readme": "https://github.com/adokter/vol2birdR/blob/main/README.md",
   "contIntegration": "https://github.com/adokter/vol2birdR/actions"

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/adokter/vol2birdR/",
   "issueTracker": "https://github.com/adokter/vol2birdR/issues",
   "license": "https://spdx.org/licenses/LGPL-3.0",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -247,7 +247,7 @@
     },
     "SystemRequirements": "GNU make, GSL, HDF5, PROJ"
   },
-  "fileSize": "14823.825KB",
+  "fileSize": "14442.861KB",
   "releaseNotes": "https://github.com/adokter/vol2birdR/blob/master/NEWS.md",
   "readme": "https://github.com/adokter/vol2birdR/blob/main/README.md",
   "contIntegration": "https://github.com/adokter/vol2birdR/actions"

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,7 +4,7 @@
   "identifier": "vol2birdR",
   "description": "'R' implementation of the 'vol2bird' software for generating vertical profiles of birds and other biological signals in weather radar data. See Dokter et al. (2011) <doi:10.1098/rsif.2010.0116> for a paper describing the methodology.",
   "name": "vol2birdR: Vertical Profiles of Biological Signals in Weather Radar Data",
-  "relatedLink": "https://adriaandokter.com/vol2bird/",
+  "relatedLink": ["https://adriaandokter.com/vol2bird/", "https://CRAN.R-project.org/package=vol2birdR"],
   "codeRepository": "https://github.com/adokter/vol2birdR/",
   "issueTracker": "https://github.com/adokter/vol2birdR/issues",
   "license": "https://spdx.org/licenses/LGPL-3.0",
@@ -14,7 +14,13 @@
     "name": "R",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 4.2.3 RC (2023-03-07 r83950)",
+  "runtimePlatform": "R version 4.3.0 (2023-04-21)",
+  "provider": {
+    "@id": "https://cran.r-project.org",
+    "@type": "Organization",
+    "name": "Comprehensive R Archive Network (CRAN)",
+    "url": "https://cran.r-project.org"
+  },
   "author": [
     {
       "@type": "Person",
@@ -241,7 +247,8 @@
     },
     "SystemRequirements": "GNU make, GSL, HDF5, PROJ"
   },
-  "fileSize": "15094.993KB",
+  "fileSize": "14823.825KB",
   "releaseNotes": "https://github.com/adokter/vol2birdR/blob/master/NEWS.md",
+  "readme": "https://github.com/adokter/vol2birdR/blob/main/README.md",
   "contIntegration": "https://github.com/adokter/vol2birdR/actions"
 }

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -12,7 +12,16 @@ OBJECTS = $(SOURCES:.cpp=.o) $(OBJECTS_C)
 PROJ_LIBS=$(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript" "../tools/get_proj_libraries.R")
 HDF5_LIBS=$(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript" "../tools/get_hdf5_libraries.R")
 H5_API_CFLAGS=$(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript" "../tools/get_h5_api_cflags.R")
-PKG_LIBS=-lpthread $(HDF5_LIBS) -lbz2  -lz  -ldl -lm $(PROJ_LIBS)
+
+# Conditional linking of libsharpyuv
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+    LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
+else
+    LIBSHARPYUV = $(shell pkg-config --libs libsharpyuv)
+endif
+
+
+PKG_LIBS=-lpthread $(HDF5_LIBS) -lbz2  -lz  -ldl -lm $(PROJ_LIBS) $(LIBSHARPYUV)
 PKG_CPPFLAGS=-D__USE_MINGW_ANSI_STDIO $(H5_API_CFLAGS)
 
 PKG_CPPFLAGS+= -I. -I./includes -I./includes/libvol2bird -I./includes/libmistnet -I./includes/librave -I./includes/libhlhdf -I./includes/librsl -I./includes/libiris2odim

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -20,7 +20,6 @@ else
     LIBSHARPYUV = $(shell pkg-config --libs libsharpyuv)
 endif
 
-
 PKG_LIBS=-lpthread $(HDF5_LIBS) -lbz2  -lz  -ldl -lm $(PROJ_LIBS) $(LIBSHARPYUV)
 PKG_CPPFLAGS=-D__USE_MINGW_ANSI_STDIO $(H5_API_CFLAGS)
 

--- a/src/mistnet.cpp
+++ b/src/mistnet.cpp
@@ -120,7 +120,6 @@ std::string cpp_vol2bird_get_wsr88d_site_location()
 //' Initializes the mistnet shared library pointed to by the path
 //'
 //' @keywords internal
-//' @param path The shared library
 // [[Rcpp::export]]
 std::string cpp_vol2bird_version() {
   return VERSION;


### PR DESCRIPTION
- refactored linking of `lsharpyuv`  according to  rtools43 [instructions](https://cran.r-project.org/bin/windows/Rtools/rtools43/news.html) 
- removed unused param from Rd file of `cpp_vol2bird_version()`