### PR TITLE
add seconds to datetime output

### DIFF
--- a/src/libvol2bird/libvol2bird.c
+++ b/src/libvol2bird/libvol2bird.c
@@ -3336,7 +3336,7 @@ int saveToCSV(const char *filename, vol2bird_t* alldata, PolarVolume_t* pvol){
         iCopied=iRowProfile*nColsProfile;
 
         char datetime[24];
-        snprintf(datetime, sizeof(datetime), "%.4s-%.2s-%.2sT%.2s:%.2s:00Z", date, date+4, date+6, time, time+2);
+        snprintf(datetime, sizeof(datetime), "%.4s-%.2s-%.2sT%.2s:%.2s:%.2sZ", date, date+4, date+6, time, time+2, time+4);
         char printbuffer[1024];
 
         //write to CSV format


### PR DESCRIPTION
Ensure a complete timestamp with seconds is written to CSV, matching the start time of the first scan.   

For some reason, seconds are incremented by 1, so for example, polar volume `KABR20200801_221731_V06` outputs a timestamp of `2020-08-01T22:17:32Z` in the CSV and `KABR20200801_111729_V06` outputs a timestamp of `2020-08-01T11:17:30Z`

Note:

- same behavior for both CSV and H5 outputs
- does not happen with polar volumes created at 00 seconds (`KABR20200801_230000_V06`, etc.) 

@andershenja any idea how this could be happening? 
