### PR TITLE
Fix linking on Windows for an upcoming version of Rtools and for Rtools42.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -14,7 +14,20 @@ OBJECTS = $(SOURCES:.cpp=.o) $(OBJECTS_C)
 PROJ_LIBS=$(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript" "../tools/get_proj_libraries.R")
 HDF5_LIBS=$(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript" "../tools/get_hdf5_libraries.R")
 H5_API_CFLAGS=$(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript" "../tools/get_h5_api_cflags.R")
-PKG_LIBS=-lpthread $(HDF5_LIBS) -lbz2  -lz  -ldl -lm $(PROJ_LIBS)
+
+# conditional linking of some dependencies needed eventually since Rtools42
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+    LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
+    LIBDEFLATE = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libdeflate.a),-ldeflate),)
+    LIBLERC = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/liblerc.a),-llerc),)
+    LIBPSL = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libpsl.a),-lpsl),)
+    LIBBROTLI = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libbrotlidec.a),-lbrotlidec -lbrotlicommon),)
+else
+    # FIXME: it would make sense to rewrite all of the above to use pkg-config
+    PDEPS = $(shell pkg-config --libs libcurl libtiff-4)
+endif
+
+PKG_LIBS=-lpthread $(HDF5_LIBS) -lbz2  -lz  -ldl -lm $(PROJ_LIBS) $(LIBBROTLI) $(LIBBROTLI) $(LIBBROTLI) $(LIBLERC) $(LIBSHARPYUV) $(LIBDEFLATE) $(PDEPS)
 PKG_CPPFLAGS=-D__USE_MINGW_ANSI_STDIO $(H5_API_CFLAGS)
 
 PKG_CPPFLAGS+= -I. -I./includes -I./includes/libvol2bird -I./includes/libmistnet -I./includes/librave -I./includes/libhlhdf -I./includes/librsl -I./includes/libiris2odim

--- a/tools/get_proj_libraries.R
+++ b/tools/get_proj_libraries.R
@@ -1,6 +1,6 @@
 if (pkgbuild::has_rtools()) {
   ver<-pkgbuild::rtools_needed()
-  LIBS<-"-lproj -lsqlite3 -lz -ldl -ltiff -lwebp -lsharpyuv -lzstd -llzma -ljpeg -lz -lcurl -lidn2 -lunistring -liconv -lcharset -lssh2 -lgcrypt -lgpg-error -lws2_32 -lgcrypt -lgpg-error -lws2_32 -lz -ladvapi32 -lcrypt32 -lssl -lcrypto -lssl -lz -lws2_32 -lgdi32 -lcrypt32 -lcrypto -lbcrypt -lz -lws2_32 -lgdi32 -lcrypt32 -lgdi32 -lwldap32 -lzstd -lz -lws2_32 -lpthread -lstdc++"
+  LIBS<-"-lproj -lsqlite3 -lz -ldl -ltiff -lwebp -lzstd -llzma -ljpeg -lz -lcurl -lidn2 -lunistring -liconv -lcharset -lssh2 -lgcrypt -lgpg-error -lws2_32 -lgcrypt -lgpg-error -lws2_32 -lz -ladvapi32 -lcrypt32 -lssl -lcrypto -lssl -lz -lws2_32 -lgdi32 -lcrypt32 -lcrypto -lbcrypt -lz -lws2_32 -lgdi32 -lcrypt32 -lgdi32 -lwldap32 -lzstd -lz -lws2_32 -lpthread -lstdc++"
   if (ver == "Rtools 4.0") {
     LIBS<-"-lproj -lsqlite3 -lz -ltiff -ljpeg -lz -lcurl -lnormaliz -lssh2 -lcrypt32 -lgdi32 -lws2_32 -lcrypt32 -lgdi32 -lws2_32 -lssl -lcrypto -lws2_32 -lgdi32 -lcrypt32 -lz -lssl -lcrypto -lssl -lcrypto -lws2_32 -lgdi32 -lcrypt32 -lgdi32 -lcrypt32 -lwldap32 -lz -lws2_32 -lstdc++"
   }


### PR DESCRIPTION
This patch is needed for the package to build on Windows with an upcoming version of Rtools, where some of the used libraries have more dependencies. It also fixed the package to build on Rtools42 (so with the change, it builds on Rtools42, 43 and to-be 44).

It uses pkg-config, where available, for libcurl and libtiff-4. This should somewhat reduce the needs for such changes in the future, while preserving the current code structure. However, I would highly recommend going away from get_*_libraries.R approach: it is not a good idea to depend on particular version of Rtools, neither it is a good idea to detect the version of Rtools the way it is done.

The recommended way is to use pkg-config, when available, directly for the libraries used by the package (e.g. proj, hdf5). To support Rtools42 and Rtools43 before pkg-config was available, the approach of conditionalizing using GNU make, on the existence of the libraries, works (as in the patch). 

If you ever wanted to support Rtools40 (R 4.1) and older, you could do that by having Makevars.win for those old version, and moving the new stuff into Makevars.ucrt (which would be used by R>=4.2). I have not tested the old versions, but I assume they wouldn't have been affected by my patch.