### PR TITLE
downgrade mistnet build os to ubuntu 22.04

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [develop, cran_release]
+    branches: [main, develop, cran_release]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 name: R-CMD-check
 

--- a/.github/workflows/mistnet.yaml
+++ b/.github/workflows/mistnet.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019, ubuntu-24.04, macos-13]
+        os: [windows-2019, ubuntu-22.04, macos-13]
         include:
           - os: windows-2019
             cuda: 0
@@ -25,7 +25,7 @@ jobs:
             flavor: Release
             artifacts: mistnet.dll
             upload: Windows        
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             library: libmistnet.so
             test: 
             make: make
@@ -54,7 +54,7 @@ jobs:
       - name: Create environment
         run: cmake -E make_directory ${{runner.workspace}}/build
       - name: Free up 24GB of disk space
-        if: ${{ matrix.os == 'ubuntu-24.04' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: sudo rm -rf /usr/share/dotnet
       - name: Run cmake
         working-directory: ${{runner.workspace}}/build
@@ -83,7 +83,7 @@ jobs:
 
   upload:
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         name:


### PR DESCRIPTION
chrpath command used in the github action is not available on ubuntu 24.04, therefore downgrading