### PR TITLE
suppress loading messages for mistnet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: vol2birdR
 Type: Package
 Title: Vertical Profiles of Biological Signals in Weather Radar Data
-Version: 1.0.3
+Version: 1.0.3.9000
 Date: 2024-07-10
 Authors@R: c(
     person("Anders", "Henja", , "anders.henja@gmail.com", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# vol2birdR 1.0.3.9000
+* reduce loading messages for mistnet
+
 # vol2birdR 1.0.3
 * Refactored conditional linking of rtools43 dependencies (#60)
 * Removed unused param from documentation in cpp_vol2bird_version()

--- a/R/install.R
+++ b/R/install.R
@@ -402,7 +402,7 @@ install_mistnet <- function(version = "1.12.1", reinstall = FALSE, path = instal
 
   message("Initializing MistNet...\n")
   if (!identical(list(...)$load, FALSE)) {
-    mistnet_start(reload = TRUE)
+    mistnet_start(reload = TRUE, verbose = FALSE)
     message("MistNet initialized successfully.\n")
   }
 

--- a/R/mistnet_load.R
+++ b/R/mistnet_load.R
@@ -11,6 +11,7 @@ mistnet_default <- function() {
 #' Initialize the 'MistNet' system if enabled.
 #' @param version version of 'MistNet' library
 #' @param reload if 'MistNet' library should be reloaded or not, default FALSE.
+#' @param verbose Logical, when `TRUE` prints text to console.
 #' @keywords internal
 mistnet_start <- function(version = mistnet_default(), reload = FALSE) {
   if (!mistnet_exists()) {
@@ -23,13 +24,13 @@ mistnet_start <- function(version = mistnet_default(), reload = FALSE) {
 
   # Path where the DLL should be
   dll_path <- file.path(install_path(), "lib")
-  message("Attempting to load MistNet from:", dll_path, "\n")
+  if(verbose) message("Attempting to load MistNet from:", dll_path, "\n")
 
   # Try-catch block to capture any errors during initialization
   tryCatch({
     cpp_mistnet_init(dll_path)
     .globals$mistnet_started <- TRUE
-      message("MistNet successfully initialized.\n")
+      if(verbose) message("MistNet successfully initialized.\n")
   }, error = function(e) {
       stop("Error during MistNet initialization: ", e$message, "\n")
   }, warning = function(w) {

--- a/R/mistnet_load.R
+++ b/R/mistnet_load.R
@@ -13,7 +13,7 @@ mistnet_default <- function() {
 #' @param reload if 'MistNet' library should be reloaded or not, default FALSE.
 #' @param verbose Logical, when `TRUE` prints text to console.
 #' @keywords internal
-mistnet_start <- function(version = mistnet_default(), reload = FALSE) {
+mistnet_start <- function(version = mistnet_default(), reload = FALSE, verbose = TRUE) {
   if (!mistnet_exists()) {
     stop("'MistNet' is disabled.")
   }

--- a/R/package.R
+++ b/R/package.R
@@ -24,7 +24,7 @@ globalVariables(c("..", "self", "private", "N"))
     # in case init fails we will just have disabled mistnet and run without it..
     tryCatch(
       {
-        mistnet_start()
+        mistnet_start(verbose = FALSE)
       },
       error = function(e) {
       }

--- a/man/mistnet_start.Rd
+++ b/man/mistnet_start.Rd
@@ -4,7 +4,7 @@
 \alias{mistnet_start}
 \title{Initialize the 'MistNet' system if enabled.}
 \usage{
-mistnet_start(version = mistnet_default(), reload = FALSE)
+mistnet_start(version = mistnet_default(), reload = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{version}{version of 'MistNet' library}

--- a/man/mistnet_start.Rd
+++ b/man/mistnet_start.Rd
@@ -10,6 +10,8 @@ mistnet_start(version = mistnet_default(), reload = FALSE)
 \item{version}{version of 'MistNet' library}
 
 \item{reload}{if 'MistNet' library should be reloaded or not, default FALSE.}
+
+\item{verbose}{Logical, when \code{TRUE} prints text to console.}
 }
 \description{
 Initialize the 'MistNet' system if enabled.


### PR DESCRIPTION
this PR removes several startup and loading messages for MistNet, by adding a `verbose` argument to `mistnet_start()` and running by default with `verbose=FALSE`