### PR TITLE
fix beam width attribute of scans

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # vol2birdR 1.2.1.9000 (development version)
+* fix beam width attribute in polar volume object (#153).
+
 * Add TDWR radar station info (#104).
 
 * Align radar locations and antenna heights with latest metadata provided by NCEI (#144).

--- a/src/librsl/wsr88d.c
+++ b/src/librsl/wsr88d.c
@@ -1176,7 +1176,7 @@ float wsr88d_get_wavelength(Wsr88d_ray *ray)
   nyquist = wsr88d_get_nyquist(ray);
     /* If required info to determine wavelength does not exist,
          just use 10 cm. All wsr88d radars are 10cm. MJK */
-  if ((prf == 0) || (nyquist == 0.0)) wavelength = 0.10;
+  if ((prf == 0) || (nyquist == 0.0)) wavelength = 0.1071;
   else wavelength = 4*nyquist/prf;
   return wavelength;
 }

--- a/src/librsl/wsr88d_m31.c
+++ b/src/librsl/wsr88d_m31.c
@@ -335,9 +335,7 @@ void wsr88d_load_ray_hdr(Wsr88d_ray_m31 *wsr88d_ray, Ray *ray)
     ray->h.azim_rate = vcp_data.azim_rate[elev_index];
     ray->h.fix_angle = vcp_data.fixed_angle[elev_index];
     ray->h.vel_res = vcp_data.vel_res;
-    if (ray_hdr.azm_res != 1)
-	ray->h.beam_width = 1.0;
-    else ray->h.beam_width = 0.5;
+    ray->h.beam_width = 0.95;
 
     /* For convenience, use message type 1 routines to get some values.
      * First load VCP and elevation numbers into a msg 1 ray.

--- a/src/libvol2bird/librsl.c
+++ b/src/libvol2bird/librsl.c
@@ -466,6 +466,11 @@ PolarVolume_t* PolarVolume_RSL2Rave(Radar* radar, float rangeMax){
         PolarVolume_addAttribute(volume, attr_wavelength);
     }
     RAVE_OBJECT_RELEASE(attr_wavelength);
+
+    // fourth, copy beamwidth from ray header
+    if (rslRay->h.beam_width > 0){
+        PolarVolume_setBeamwidth(volume, rslRay->h.beam_width*PI/180);
+    }
         
     // read the RSL scans (sweeps) and add them to RAVE polar volume
     int result;

--- a/src/libvol2bird/librsl.c
+++ b/src/libvol2bird/librsl.c
@@ -285,7 +285,7 @@ PolarScan_t* PolarScan_RSL2Rave(Radar *radar, int iScan, float rangeMax){
     PolarScan_setElangle(scan, (double) rslVol->sweep[iScan]->h.elev*PI/180);
 
     // add attribute Beamwidth to scan
-    PolarScan_setBeamwidth(scan, (double) rslVol->sweep[iScan]->h.beam_width);
+    PolarScan_setBeamwidth(scan, (double) rslVol->sweep[iScan]->h.beam_width*PI/180);
 
     // add attribute Nyquist velocity to scan (from radial velocity sweep)
     if(iScan > radar->v[VR_INDEX]->h.nsweeps-1){


### PR DESCRIPTION
This PR includes two changes:

1) For scan objects: Beam wave attribute was stored as degrees instead of radians, therefore decoding into a large value. Corrected by multiplying by pi/180. This is not affecting existing range corrections in bioRad, since these so far haven't used the beam width attribute of individual scans directly.

2) For polar volume objects: the polar volume level beam width attribute is changed from a 1 degree default to the actual decoded value. For NEXRAD this means a change from 1.0 deg to 0.95 deg.